### PR TITLE
Update LOA link as requested by Natalia 

### DIFF
--- a/_partners/家长资讯 For Parents/行政与财政 Admin & Finance.md
+++ b/_partners/家长资讯 For Parents/行政与财政 Admin & Finance.md
@@ -13,7 +13,7 @@ variant: tiptap
 </p>
 </li>
 <li>
-<p><a href="https://go.gov.sg/loa-form-2025" rel="noopener noreferrer nofollow" target="_blank">2025 Leave of Absence Form</a>
+<p><a href="https://go.gov.sg/2025-loa-form-tns" rel="noopener noreferrer nofollow" target="_blank">2025 Leave of Absence Form</a>
 </p>
 </li>
 <li>


### PR DESCRIPTION
Due to the discontinuation of the email mode forms on FormSG, we will need to update the short link of the LOA form(https://go.gov.sg/loa-form-2025) on the school website to the storage mode form. Below is the new link for your action:

https://go.gov.sg/2025-loa-form-tns
