### PR TITLE
Add 2026 LOA 

### DIFF
--- a/_partners/家长资讯 For Parents/行政与财政 Admin & Finance.md
+++ b/_partners/家长资讯 For Parents/行政与财政 Admin & Finance.md
@@ -20,6 +20,10 @@ variant: tiptap
 <p><a href="https://go.gov.sg/2025-waiting-list" rel="noopener nofollow" target="_blank">2025 Waiting List Form</a>
 </p>
 </li>
+<li>
+<p><a href="https://go.gov.sg/2026-loa-form-tns" rel="noopener noreferrer nofollow" target="_blank">2026 Leave of Absence Form</a>
+</p>
+</li>
 </ul>
 <h3>Finance</h3>
 <ul data-tight="true" class="tight">


### PR DESCRIPTION
Please help to add 2026 Leave of Absence Form to the school website under the following link:
https://www.taonan.moe.edu.sg/partners/for-parents/admin-n-finance/forms/

Below is the FormSG link for uploading:
https://form.gov.sg/67d910acf5a3f0517eab3004

Or shortcut link:
https://go.gov.sg/2026-loa-form-tns

2025 Leave of Absence Form can be removed from the school website after 30 September 2025. Thank you.


Best Regards,

Natalia Sugiarto (Nat) | Corporate Support Officer
Tao Nan School 道南学校 | 49 Marine Crescent, Singapore 449761
Tel: (65) 6442 8307 | Fax: (65) 6443 5973 | Web: www.taonan.moe.edu.sg